### PR TITLE
Improve regular expression syntax support

### DIFF
--- a/greenery/lego.py
+++ b/greenery/lego.py
@@ -1885,6 +1885,8 @@ escapes = {
 	"\v" : "\\v", # vertical tab
 	"\f" : "\\f", # form feed
 	"\r" : "\\r", # carriage return
+	"'": "\\'",  # single quote
+	"\"":  "\\\"", # double quote
 }
 
 # Use this for cases where no upper bound is needed

--- a/greenery/lego.py
+++ b/greenery/lego.py
@@ -454,7 +454,7 @@ class charclass(lego):
 	classSpecial = set("\\[]^-")
 
 	# These are the characters which may be first inside char class definition and may not be escaped
-	classFirstCharSpecialCases = set('-')
+	classFirstOrLastCharSpecialCases = set('-')
 
 	# Shorthand codes for use inside charclasses e.g. [abc\d]
 	w = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
@@ -656,7 +656,14 @@ class charclass(lego):
 
 		def matchClassInteriorFirst(string, i):
 			try:
-				return select_static(string, i, *charclass.classFirstCharSpecialCases)
+				return select_static(string, i, *charclass.classFirstOrLastCharSpecialCases)
+			except nomatch:
+				pass
+			return matchClassInterior1(string, i)
+
+		def matchClassInteriorLast(string, i):
+			try:
+				return select_static(string, i, *charclass.classFirstOrLastCharSpecialCases)
 			except nomatch:
 				pass
 			return matchClassInterior1(string, i)
@@ -699,7 +706,10 @@ class charclass(lego):
 				internal, i = matchClassInteriorFirst(string, i)
 				internals += internal
 				while True:
-					internal, i = matchClassInterior1(string, i)
+					if string[i+1:i+2] == ']':
+						internal, i = matchClassInteriorLast(string, i)
+					else:
+						internal, i = matchClassInterior1(string, i)
 					internals += internal
 			except nomatch:
 				pass

--- a/greenery/lego.py
+++ b/greenery/lego.py
@@ -360,6 +360,50 @@ class lego:
 
 			yield "".join(string)
 
+
+class anchor(lego):
+	def __init__(self, v):
+		self.__dict__["v"] = v
+
+	def __eq__(self, other):
+		try:
+			return self.v == other.v
+		except AttributeError:
+			return False
+
+	def __ne__(self, other):
+		return not self.__eq__(other)
+
+	def __hash__(self):
+		return hash(self.v)
+
+	def __str__(self):
+		return anchors[self]
+
+	@reduce_after
+	def reduce(self):
+		return self
+
+	def __repr__(self):
+		return "anchor(%s)" % anchors[self]
+
+	def empty(self):
+		return False
+
+	@classmethod
+	def match(cls, string, i = 0):
+		for _anchor, value in anchors.iteritems():
+			try:
+				return _anchor, static(string, i, value)
+			except nomatch:
+				pass
+
+		raise nomatch
+
+	def __reversed__(self):
+		return self
+
+
 class charclass(lego):
 	'''
 		A charclass is basically a frozenset of symbols. The reason for the
@@ -1441,7 +1485,10 @@ class conc(lego):
 		mults = list()
 		try:
 			while True:
-				m, i = mult.match(string, i)
+				try:
+					m, i = anchor.match(string, i)
+				except nomatch:
+					m, i = mult.match(string, i)
 				mults.append(m)
 		except nomatch:
 			pass
@@ -1828,6 +1875,8 @@ escapes = {
 	"\v" : "\\v", # vertical tab
 	"\f" : "\\f", # form feed
 	"\r" : "\\r", # carriage return
+	"\\b": "\\b",
+	"\\B": "\\B",
 }
 
 # Use this for cases where no upper bound is needed
@@ -1854,3 +1903,23 @@ symbolic = {
 
 # A very special conc expressing the empty string, ""
 emptystring = conc()
+
+b = anchor("\\b")
+B = anchor("\\B")
+G = anchor("\\G")
+z = anchor("\\z")
+Z = anchor("\\Z")
+A = anchor("\\A")
+dollar = anchor("$")
+caret = anchor("^")
+
+anchors = {
+	b: b.v,
+	B: B.v,
+	G: G.v,
+	z: z.v,
+	Z: Z.v,
+	A: A.v,
+	dollar: dollar.v,
+	caret: caret.v,
+}

--- a/greenery/lego.py
+++ b/greenery/lego.py
@@ -1885,8 +1885,6 @@ escapes = {
 	"\v" : "\\v", # vertical tab
 	"\f" : "\\f", # form feed
 	"\r" : "\\r", # carriage return
-	"\\b": "\\b",
-	"\\B": "\\B",
 }
 
 # Use this for cases where no upper bound is needed

--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -1327,3 +1327,13 @@ def test_block_comment_regex():
 def test_named_groups():
 	a = parse("(?P<ng1>abc)")
 	assert a.matches("abc")
+
+def test_lazy_quantifier():
+	a = parse('a*?b+?c')
+	assert a.matches('abc')
+	assert a.matches('bbc')
+
+def test_special_cases_for_first_character_in_char_class():
+	a = parse('[- ]')
+	assert a.matches('-')
+	assert a.matches(' ')

--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -3,7 +3,7 @@
 if __name__ == "__main__":
 	raise Exception("Test files can't be run directly. Use `python -m pytest greenery`")
 
-from greenery.lego import conc, mult, charclass, one, emptystring, star, plus, nothing, pattern, qm, d, multiplier, bound, w, s, W, D, S, dot, nomatch, inf, zero, parse, from_fsm
+from greenery.lego import conc, mult, charclass, one, emptystring, star, plus, nothing, pattern, qm, d, multiplier, bound, w, s, W, D, S, dot, nomatch, inf, zero, parse, from_fsm, dollar, caret
 from greenery import fsm
 
 def test_new_reduce():
@@ -1337,3 +1337,13 @@ def test_special_cases_for_first_character_in_char_class():
 	a = parse('[- ]')
 	assert a.matches('-')
 	assert a.matches(' ')
+
+def test_parse_anchors():
+	assert str(parse(r"\ba\b")) == r"\ba\b"
+	assert str(parse(r"^a$")) == r"^a$"
+	assert str(parse(r"\Aa\Z")) == r"\Aa\Z"
+	assert str(parse(r"\Ga\z")) == r"\Ga\z"
+	a = parse(r"^a$")
+	mults = list(list(a.concs)[0].mults)
+	assert mults[0] == caret
+	assert mults[2] == dollar

--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -213,7 +213,7 @@ def test_charclass_str():
 	assert str(charclass("\\")) == "\\\\"
 	assert str(charclass("a^")) == "[\\^a]"
 	assert str(charclass("0123456789a")) == "[0-9a]"
-	assert str(charclass("\t\v\r A")) == "[\\t\\v\\r A]"
+	assert str(charclass("\t\v\r' \"'A")) == "[\\t\\v\\r \\\"\\'A]"
 	assert str(charclass("\n\f A")) == "[\\n\\f A]"
 	assert str(charclass("\t\n\v\f\r A")) == "[\\t-\\r A]"
 	assert str(charclass("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz|")) == "[0-9A-Z_a-z|]"

--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -1333,8 +1333,11 @@ def test_lazy_quantifier():
 	assert a.matches('abc')
 	assert a.matches('bbc')
 
-def test_special_cases_for_first_character_in_char_class():
+def test_special_cases_for_charclass():
 	a = parse('[- ]')
+	assert a.matches('-')
+	assert a.matches(' ')
+	a = parse('[ -]')
 	assert a.matches('-')
 	assert a.matches(' ')
 


### PR DESCRIPTION
I added some missing cases: 

1. `-` at start and at end of `[...]` without escape character which is valid case for regular expression and doesn't creates range);
1. Escapes for `'`  and `"`
1. Most significant change - anchors (like '$' and '^' or '\b', '\B' etc). They are added as separate lego type, because they doesn't match any existing concept. But they didn't work with fsm, because they didn't advance sequence and may depends on previous characters or matches. So regex with anchors may be parsed, but can't be used with `matches` method.