### PR TITLE
rename class anything_else to allow pickling

### DIFF
--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -4,7 +4,7 @@
 	Finite state machine library.
 '''
 
-class anything_else:
+class anything_else_cls:
 	'''
 		This is a surrogate symbol which you can use in your finite state machines
 		to represent "any symbol not in the official alphabet". For example, if your
@@ -19,7 +19,7 @@ class anything_else:
 
 # We use a class instance because that gives us control over how the special
 # value gets serialised. Otherwise this would just be `object()`.
-anything_else = anything_else()
+anything_else = anything_else_cls()
 
 def key(symbol):
 	'''Ensure `fsm.anything_else` always sorts last'''


### PR DESCRIPTION
Python's pickling did not work on FSM objects. I did not dig too
much into it, but this made pickling work.  My guess so far is that
the old code overwrote greenery.fsm.anything_else, which makes the
class definition unavailable after the import (and when
pickling/unpickling).